### PR TITLE
Fixed exception caused by printing CUDA program object

### DIFF
--- a/reikna/cluda/api.py
+++ b/reikna/cluda/api.py
@@ -421,7 +421,7 @@ class Thread:
             self._released = True
 
 
-class Program:
+class Program(object):
     """
     An object with compiled GPU code.
 


### PR DESCRIPTION
Hi, I found the following issue when using the CUDA API:

```
>>> import reikna.cluda
>>> api = reikna.cluda.cuda_api()
>>> thr = api.Thread.create()
>>> prg = thr.compile('')
>>> print prg
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "reikna/cluda/api.py", line 452, in __getattr__
    return self._thr.api.Kernel(self._thr, self._program, name, static=self._static)
  File "reikna/cluda/api.py", line 469, in __init__
    self._static = static
  File "reikna/cluda/cuda.py", line 208, in _get_kernel
    return program.get_function(name)
  File ".../pycuda/compiler.py", line 275, in get_function
    return self.module.get_function(name)
pycuda._driver.LogicError: cuModuleGetFunction failed: not found
```

It looks like print tries to use `prg.__repr__`, so prg looks for a function called "`__repr__`". I changed reikna.cluda.api.Program to inherit from object so it behaves as a "new-style class", which apparently causes it to use the default `__repr__` implementation instead of calling `prg.__getattr__("__repr__")`.
