### PR TITLE
Add Array._new_like_me method to fix PyOpenCL copying

### DIFF
--- a/reikna/cluda/ocl.py
+++ b/reikna/cluda/ocl.py
@@ -7,6 +7,7 @@ from reikna.helpers import wrap_in_tuple
 import reikna.cluda as cluda
 import reikna.cluda.dtypes as dtypes
 import reikna.cluda.api as api_base
+import reikna.core
 
 
 def get_id():
@@ -25,6 +26,16 @@ class Array(clarray.Array):
         clarray.Array.__init__(self, thr._queue, *args, **kwds)
         self.thread = thr
 
+    def _new_like_me(self, dtype=None):
+        """
+        Called by PyOpenCL when the array is copied, to make an empty array.
+        The default PyOpenCL implementation tries to make a new Array
+        passing a CommandQueue instead of a reikna Thread.
+        """
+        return (self.thread.empty_like(self)
+                if dtype is None
+                else self.thread.empty_like(reikna.core.Type(dtype,
+                                                             self.shape)))
 
 class Thread(api_base.Thread):
 


### PR DESCRIPTION
I've found an error when copying a Reikna Array using PyOpenCL. To reproduce the error:

    >>> import reikna.cluda
    >>> api = reikna.cluda.ocl_api()
    >>> import pyopencl
    >>> thr = api.Thread(pyopencl.create_some_context())
    >>> from reikna.core import Type
    >>> import numpy as np
    >>> arr = thr.empty_like(Type(np.float32, (2,2)))
    >>> arr.copy()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File ".../site-packages/pyopencl/array.py", line 674, in copy
        result = self._new_like_me()
      File ".../site-packages/pyopencl/array.py", line 828, in _new_like_me
        allocator=self.allocator, strides=strides)
      File "reikna/cluda/ocl.py", line 25, in __init__
        clarray.Array.__init__(self, thr._queue, *args, **kwds)
    AttributeError: 'CommandQueue' object has no attribute '_queue'

The problem seems to be that pyopencl.array.Array has a _new_like_me method that creates a new empty array. When it's called on a reikna.cluda.ocl.Array subclass, it tries to create a new Reikna Array with a PyOpenCL CommandQueue instead of a Reikna Thread. The custom _new_like_me method should fix this issue.